### PR TITLE
修复useTable在total为0时的bug

### DIFF
--- a/src/hooks/web/useTable.ts
+++ b/src/hooks/web/useTable.ts
@@ -136,9 +136,7 @@ export const useTable = <T = any>(config?: UseTableConfig<T>) => {
       })
       if (res) {
         tableObject.tableList = (res as unknown as ResponseType).list
-        if ((res as unknown as ResponseType).total) {
-          tableObject.total = (res as unknown as ResponseType).total as unknown as number
-        }
+        tableObject.total = (res as unknown as ResponseType).total ?? 0
       }
     },
     setProps: async (props: TableProps = {}) => {


### PR DESCRIPTION
如果total为0，tableObject 的 total 不会被更新，在搜索后即使没有结果，共x项结果还显示原来的数字
```js
if ((res as unknown as ResponseType).total) {
  tableObject.total = (res as unknown as ResponseType).total as unknown as number
}
```