### PR TITLE
fix: 修复在用户设置alwaysShow:true的情况下,多个子菜单中只有一个显示的子菜单设导致置无效的问题

### DIFF
--- a/src/utils/routerHelper.ts
+++ b/src/utils/routerHelper.ts
@@ -69,10 +69,7 @@ export const generateRoute = (routes: AppCustomRouteRecordRaw[]): AppRouteRecord
       icon: route.icon,
       hidden: !route.visible,
       noCache: !route.keepAlive,
-      alwaysShow:
-        route.children &&
-        route.children.length === 1 &&
-        (route.alwaysShow !== undefined ? route.alwaysShow : true)
+      alwaysShow:route.alwaysShow
     }
     // 路由地址转首字母大写驼峰，作为路由名称，适配keepAlive
     let data: AppRouteRecordRaw = {


### PR DESCRIPTION
用户界面中新增的菜单项必存在alwaysShow这个值，且给用户的直觉是设置了总是显示之后，不管子菜单有多少项都会显示父级菜单，而在代码中，在有多个子菜单且只有一个显示子菜单的情况下，alwaysShow永远是false。

在菜单渲染的逻辑中，只含可显示子菜单的情况下才会走alwaysShow相关的逻辑，按照用户界面的逻辑来看，alwaysShow应该是在特定情况下的一个独断的布尔值，所以感觉不应该在动态生成路由的过程中，用其他情况来修改alwaysShow的值。

: ）第一次提pull request，有问题的地方还请指出