### PR TITLE
【修复】商城管理首页统计数据显示问题

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -313,7 +313,7 @@ export const fenToYuan = (price: string | number): string => {
  */
 export const calculateRelativeRate = (value?: number, reference?: number) => {
   // 防止除0
-  if (!reference) return 0
+  if (!reference || reference == 0) return 0
 
   return ((100 * ((value || 0) - reference)) / reference).toFixed(0)
 }

--- a/src/views/mall/home/components/TradeTrendCard.vue
+++ b/src/views/mall/home/components/TradeTrendCard.vue
@@ -186,7 +186,7 @@ const getOrderCountTrendComparison = async (
     dates.push(item.value.date)
     if (series.length === 2) {
       series[0].data.push(fenToYuan(item?.value?.orderPayPrice || 0)) // 当前金额
-      series[1].data.push(fenToYuan(item?.value?.orderPayCount || 0)) // 当前数量
+      series[1].data.push(item?.value?.orderPayCount || 0) // 当前数量
     } else {
       series[0].data.push(fenToYuan(item?.reference?.orderPayPrice || 0)) // 对照金额
       series[1].data.push(fenToYuan(item?.value?.orderPayPrice || 0)) // 当前金额


### PR DESCRIPTION
修复商城首页中交易量趋势里订单数量显示错误，销售额计算环比时，若昨日为零，即0.00则绕过了判断，展示为无穷大