### PR TITLE
【功能优化】添加商品属性时允许选择已有的属性值

### DIFF
--- a/src/views/mall/product/spu/components/SkuList.vue
+++ b/src/views/mall/product/spu/components/SkuList.vue
@@ -24,7 +24,7 @@
       >
         <template #default="{ row }">
           <span style="font-weight: bold; color: #40aaff">
-            {{ row.properties[index]?.valueName }}
+            {{ row.properties?.[index]?.valueName }}
           </span>
         </template>
       </el-table-column>
@@ -168,7 +168,7 @@
       >
         <template #default="{ row }">
           <span style="font-weight: bold; color: #40aaff">
-            {{ row.properties[index]?.valueName }}
+            {{ row.properties?.[index]?.valueName }}
           </span>
         </template>
       </el-table-column>
@@ -248,7 +248,7 @@
       >
         <template #default="{ row }">
           <span style="font-weight: bold; color: #40aaff">
-            {{ row.properties[index]?.valueName }}
+            {{ row.properties?.[index]?.valueName }}
           </span>
         </template>
       </el-table-column>

--- a/src/views/mall/product/spu/components/index.ts
+++ b/src/views/mall/product/spu/components/index.ts
@@ -5,6 +5,7 @@ interface PropertyAndValues {
   id: number
   name: string
   values?: PropertyAndValues[]
+  propertyOpts?: PropertyAndValues[]
 }
 
 interface RuleConfig {

--- a/src/views/mall/product/spu/form/ProductAttributes.vue
+++ b/src/views/mall/product/spu/form/ProductAttributes.vue
@@ -37,7 +37,7 @@
           v-for="item2 in item.propertyOpts"
           :key="item2.id"
           :label="item2.name"
-          :value="item2.name"
+          :value="item2.id"
         />
       </el-select>
       <el-button
@@ -57,6 +57,7 @@
 import * as PropertyApi from '@/api/mall/product/property'
 import { PropertyAndValues } from '@/views/mall/product/spu/components'
 import { propTypes } from '@/utils/propTypes'
+import { isNumber } from '@/utils/is'
 
 defineOptions({ name: 'ProductAttributes' })
 
@@ -121,11 +122,13 @@ const emit = defineEmits(['success']) // 定义 success 事件，用于操作成
 const handleInputConfirm = async (index: number, propertyId: number) => {
   if (inputValue.value) {
     // 重复添加校验
-    if (attributeList.value[index].values.find((item) => item.name === inputValue.value)) {
-      message.warning('已存在相同属性值，请重试')
-      attributeIndex.value = null
-      inputValue.value = ''
-      return
+    if (isNumber(inputValue.value)) {
+      if (attributeList.value[index].values?.some((item) => item.id === inputValue.value)) {
+        message.warning('已存在相同属性值，请重试')
+        attributeIndex.value = null
+        inputValue.value = ''
+        return
+      }
     }
     // 保存属性值
     try {

--- a/src/views/mall/product/spu/form/ProductAttributes.vue
+++ b/src/views/mall/product/spu/form/ProductAttributes.vue
@@ -18,16 +18,28 @@
       >
         {{ value.name }}
       </el-tag>
-      <el-input
-        v-show="inputVisible(index)"
+      <el-select
         :id="`input${index}`"
         :ref="setInputRef"
+        v-show="inputVisible(index)"
         v-model="inputValue"
-        class="!w-20"
+        filterable
+        allow-create
+        default-first-option
+        :reserve-keyword="false"
         size="small"
+        class="!w-30"
         @blur="handleInputConfirm(index, item.id)"
         @keyup.enter="handleInputConfirm(index, item.id)"
-      />
+      >
+        <el-option
+          v-for="item2 in item.propertyOpts"
+          :key="item2.id"
+          :label="item2.name"
+          :value="item2.name"
+        />
+      </el-select>
+      <!-- <el-input :id="`input${index}`" v-model="inputValue" class="!w-20" /> -->
       <el-button
         v-show="!inputVisible(index)"
         class="button-new-tag ml-1"
@@ -109,6 +121,13 @@ const showInput = async (index) => {
 const emit = defineEmits(['success']) // 定义 success 事件，用于操作成功后的回调
 const handleInputConfirm = async (index: number, propertyId: number) => {
   if (inputValue.value) {
+    // 重复添加校验
+    if (attributeList.value[index].values.find((item) => item.name === inputValue.value)) {
+      message.warning('已存在相同属性值，请重试')
+      attributeIndex.value = null
+      inputValue.value = ''
+      return
+    }
     // 保存属性值
     try {
       const id = await PropertyApi.createPropertyValue({ propertyId, name: inputValue.value })

--- a/src/views/mall/product/spu/form/ProductAttributes.vue
+++ b/src/views/mall/product/spu/form/ProductAttributes.vue
@@ -31,6 +31,7 @@
         class="!w-30"
         @blur="handleInputConfirm(index, item.id)"
         @keyup.enter="handleInputConfirm(index, item.id)"
+        @change="handleInputConfirm(index, item.id)"
       >
         <el-option
           v-for="item2 in item.propertyOpts"
@@ -39,7 +40,6 @@
           :value="item2.name"
         />
       </el-select>
-      <!-- <el-input :id="`input${index}`" v-model="inputValue" class="!w-20" /> -->
       <el-button
         v-show="!inputVisible(index)"
         class="button-new-tag ml-1"
@@ -54,7 +54,6 @@
 </template>
 
 <script lang="ts" setup>
-import { ElInput } from 'element-plus'
 import * as PropertyApi from '@/api/mall/product/property'
 import { PropertyAndValues } from '@/views/mall/product/spu/components'
 import { propTypes } from '@/utils/propTypes'

--- a/src/views/mall/product/spu/form/ProductPropertyAddForm.vue
+++ b/src/views/mall/product/spu/form/ProductPropertyAddForm.vue
@@ -99,15 +99,14 @@ const submitForm = async () => {
       values: []
     })
     // 判断最终提交的属性名称是否是选择的 自己手动输入的属性名称不执行emit
-    attrOption.value.forEach((item) => {
-      if (item.name === formData.value.name) {
-        emit('success', propertyId, item.id)
+    for (const element of attrOption.value) {
+      if (element.name === formData.value.name) {
+        emit('success', propertyId, element.id)
         message.success(t('common.createSuccess'))
         dialogVisible.value = false
-        // 中断循环
-        throw new Error()
+        return
       }
-    })
+    }
     message.success(t('common.createSuccess'))
     dialogVisible.value = false
   } finally {
@@ -127,6 +126,7 @@ const resetForm = () => {
 const getAttrOption = async () => {
   formLoading.value = true
   try {
+    // TODO @芋艿：需要增加一个全列表接口
     const data = await PropertyApi.getPropertyPage({ pageNo: 1, pageSize: 100 })
     attrOption.value = data.list
   } finally {

--- a/src/views/mall/product/spu/form/SkuForm.vue
+++ b/src/views/mall/product/spu/form/SkuForm.vue
@@ -201,6 +201,7 @@ const generateSkus = (propertyList: any[]) => {
 const getPropertyValueList = async (id, propertyId) => {
   formLoading.value = true
   try {
+    // TODO @芋艿：需要增加一个全列表接口
     const data = await PropertyApi.getPropertyValuePage({ pageNo: 1, pageSize: 100, propertyId })
     propertyList.value.find((item) => item.id === id).propertyOpts = data.list
   } finally {

--- a/src/views/mall/product/spu/form/SkuForm.vue
+++ b/src/views/mall/product/spu/form/SkuForm.vue
@@ -1,6 +1,13 @@
 <!-- 商品发布 - 库存价格 -->
 <template>
-  <el-form ref="formRef" :disabled="isDetail" :model="formData" :rules="rules" label-width="120px">
+  <el-form
+    ref="formRef"
+    :disabled="isDetail"
+    :model="formData"
+    :rules="rules"
+    label-width="120px"
+    v-loading="formLoading"
+  >
     <el-form-item label="分销类型" props="subCommissionType">
       <el-radio-group
         v-model="formData.subCommissionType"
@@ -51,9 +58,14 @@
   </el-form>
 
   <!-- 商品属性添加 Form 表单 -->
-  <ProductPropertyAddForm ref="attributesAddFormRef" :propertyList="propertyList" />
+  <ProductPropertyAddForm
+    ref="attributesAddFormRef"
+    :propertyList="propertyList"
+    @success="getPropertyValueList"
+  />
 </template>
 <script lang="ts" setup>
+import * as PropertyApi from '@/api/mall/product/property'
 import { PropType } from 'vue'
 import { copyValueToTarget } from '@/utils'
 import { propTypes } from '@/utils/propTypes'
@@ -94,7 +106,7 @@ const ruleConfig: RuleConfig[] = [
 ]
 
 const message = useMessage() // 消息弹窗
-
+const formLoading = ref(false)
 const props = defineProps({
   propFormData: {
     type: Object as PropType<Spu>,
@@ -183,5 +195,16 @@ const onChangeSpec = () => {
 /** 调用 SkuList generateTableData 方法*/
 const generateSkus = (propertyList: any[]) => {
   skuListRef.value.generateTableData(propertyList)
+}
+
+/* 获取属性值列表 */
+const getPropertyValueList = async (id, propertyId) => {
+  formLoading.value = true
+  try {
+    const data = await PropertyApi.getPropertyValuePage({ pageNo: 1, pageSize: 100, propertyId })
+    propertyList.value.find((item) => item.id === id).propertyOpts = data.list
+  } finally {
+    formLoading.value = false
+  }
 }
 </script>


### PR DESCRIPTION
Fixes #47
![image](https://github.com/user-attachments/assets/2b1e64b2-9a44-493d-8008-256570905790)
允许下拉选择/自行输入添加商品属性
![image](https://github.com/user-attachments/assets/ff3d7598-1bb9-431c-b5dd-94b1e3f43f7e)
以及允许下拉选择/自行输入添加商品属性值
![image](https://github.com/user-attachments/assets/c4bb6121-9480-4bc6-bb10-6ef1310b4880)
增加重复选择商品属性值校验，发出提示