### PR TITLE
修复使用dictTag组件会出现位置偏移问题

### DIFF
--- a/src/components/DictTag/src/DictTag.vue
+++ b/src/components/DictTag/src/DictTag.vue
@@ -57,7 +57,7 @@ export default defineComponent({
         <div
           class="dict-tag"
           style={{
-            display: 'flex',
+            display: 'inline-flex',
             gap: props.gutter,
             justifyContent: 'center',
             alignItems: 'center'


### PR DESCRIPTION
> https://github.com/yudaocode/yudao-ui-admin-vue3/pull/68#issuecomment-2285249944
修复使用dictTag组件会出现位置偏移问题
![image](https://github.com/user-attachments/assets/17823262-f85f-4728-8b65-3da90c22ac66)
![image](https://github.com/user-attachments/assets/972aee2d-8280-4627-b73e-9aedb1880d0b)
