### PR TITLE
bugfix: 移动端浅色模式下标题语言颜色异常

### DIFF
--- a/src/views/Login/Login.vue
+++ b/src/views/Login/Login.vue
@@ -32,15 +32,16 @@
       >
         <!-- 右上角的主题、语言选择 -->
         <div
-          class="flex items-center justify-between text-white at-2xl:justify-end at-xl:justify-end"
+          class="flex items-center justify-between at-2xl:justify-end at-xl:justify-end"
+          style="color: var(--el-text-color-primary);"
         >
           <div class="flex items-center at-2xl:hidden at-xl:hidden">
             <img alt="" class="mr-10px h-48px w-48px" src="@/assets/imgs/logo.png" />
-            <span class="text-20px font-bold">{{ underlineToHump(appStore.getTitle) }}</span>
+            <span class="text-20px font-bold" >{{ underlineToHump(appStore.getTitle) }}</span>
           </div>
           <div class="flex items-center justify-end space-x-10px h-48px">
             <ThemeSwitch />
-            <LocaleDropdown class="dark:text-white lt-xl:text-white" />
+            <LocaleDropdown />
           </div>
         </div>
         <!-- 右边的登录界面 -->


### PR DESCRIPTION
移动端模式下，浅色背景导致标题与背景融为一体，直接使用 Element UI 自带的颜色变量