### PR TITLE
修复现象:pnpm install的情况下流程表单设计的组件缺失

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,10 +13,10 @@ importers:
         version: 2.3.1(vue@3.4.21(typescript@5.3.3))
       '@form-create/designer':
         specifier: ^3.1.3
-        version: 3.1.5(vue@3.4.21(typescript@5.3.3))
+        version: 3.2.5(vue@3.4.21(typescript@5.3.3))
       '@form-create/element-ui':
         specifier: ^3.1.24
-        version: 3.1.29(vue@3.4.21(typescript@5.3.3))
+        version: 3.2.8(vue@3.4.21(typescript@5.3.3))
       '@iconify/iconify':
         specifier: ^3.1.1
         version: 3.1.1


### PR DESCRIPTION
原因分析:在按照芋道官方文档的pnpm install时,会因该pnpm-lock.yaml文件的存在,导致流程表单设计的组件部分缺失,分析其原因是因为form-create在pnpm仓3.1.5版本的代码并不存在,但是在3.2.5的版本存在,可能是form-create作者尚未及时同步上传3.1.5版本代码 解决方案:
1.合并本次PR
2.或者删除掉pnpm-lock.yaml,使pnpm install时安装最新依赖
3.或者不使用pnpm命令,仅npm命令