### PR TITLE
fix: Update useRenderLayout.tsx add tagsView.value when rendertop

### DIFF
--- a/src/layout/components/useRenderLayout.tsx
+++ b/src/layout/components/useRenderLayout.tsx
@@ -197,7 +197,7 @@ export const useRenderLayout = () => {
               `${prefixCls}-content-scrollbar`,
               {
                 '!h-[calc(100%-var(--tags-view-height))] mt-[calc(var(--tags-view-height))]':
-                  fixedHeader.value
+                  fixedHeader.value && tagsView.value
               }
             ]}
           >


### PR DESCRIPTION
if I set tagsview value `false` in app.ts initial. the content will have margin top style.