### PR TITLE
feat(social-client): 三方应用页面列表、表单增加字段

### DIFF
--- a/src/api/system/social/client/index.ts
+++ b/src/api/system/social/client/index.ts
@@ -1,14 +1,17 @@
 import request from '@/config/axios'
 
 export interface SocialClientVO {
-  id: number
-  name: string
-  socialType: number
-  userType: number
-  clientId: string
-  clientSecret: string
-  agentId: string
-  status: number
+    id: number
+    name: string
+    socialType: number
+    userType: number
+    clientId: string
+    clientSecret: string
+    agentId: string
+    status: number
+    redirectUri: string
+    ignoreCheckRedirectUri: boolean
+    ignoreCheckState: boolean
 }
 
 // 查询社交客户端列表

--- a/src/views/system/social/client/SocialClientForm.vue
+++ b/src/views/system/social/client/SocialClientForm.vue
@@ -41,9 +41,25 @@
           placeholder="请输入客户端密钥,对应各平台的appSecret"
         />
       </el-form-item>
+      <el-form-item label="回调地址" prop="redirectUri">
+        <el-input v-model="formData.redirectUri" placeholder="请输入登录成功后的回调地址" />
+      </el-form-item>
       <el-form-item label="agentId" prop="agentId" v-if="formData!.socialType === 30">
         <el-input v-model="formData.agentId" placeholder="授权方的网页应用 ID，有则填" />
       </el-form-item>
+      <el-form-item label="忽略校验uri" prop="ignoreCheckRedirectUri">
+        <el-radio-group v-model="formData.ignoreCheckRedirectUri">
+          <el-radio :label="true">是</el-radio>
+          <el-radio :label="false">否</el-radio>
+        </el-radio-group>
+      </el-form-item>
+      <el-form-item label="忽略校验state" prop="ignoreCheckState">
+        <el-radio-group v-model="formData.ignoreCheckState">
+          <el-radio :label="true">是</el-radio>
+          <el-radio :label="false">否</el-radio>
+        </el-radio-group>
+      </el-form-item>
+
       <el-form-item label="状态" prop="status">
         <el-radio-group v-model="formData.status">
           <el-radio
@@ -81,6 +97,9 @@ const formData = ref({
   clientId: undefined,
   clientSecret: undefined,
   agentId: undefined,
+  redirectUri: undefined,
+  ignoreCheckRedirectUri: undefined,
+  ignoreCheckState: undefined,
   status: 0
 })
 const formRules = reactive({
@@ -89,6 +108,8 @@ const formRules = reactive({
   userType: [{ required: true, message: '用户类型不能为空', trigger: 'blur' }],
   clientId: [{ required: true, message: '客户端编号不能为空', trigger: 'blur' }],
   clientSecret: [{ required: true, message: '客户端密钥不能为空', trigger: 'blur' }],
+  ignoreCheckRedirectUri: [{ required: true, message: '忽略校验uri不能为空', trigger: 'blur' }],
+  ignoreCheckState: [{ required: true, message: '忽略校验state不能为空', trigger: 'blur' }],
   status: [{ required: true, message: '状态不能为空', trigger: 'blur' }]
 })
 const formRef = ref() // 表单 Ref

--- a/src/views/system/social/client/index.vue
+++ b/src/views/system/social/client/index.vue
@@ -111,6 +111,16 @@
           <dict-tag :type="DICT_TYPE.COMMON_STATUS" :value="scope.row.status" />
         </template>
       </el-table-column>
+      <el-table-column align="center" label="忽略校验uri" prop="ignoreCheckRedirectUri">
+        <template #default="scope">
+          {{ scope.row.ignoreCheckRedirectUri ? '是' : '否' }}
+        </template>
+      </el-table-column>
+      <el-table-column align="center" label="忽略校验state" prop="ignoreCheckState">
+        <template #default="scope">
+          {{ scope.row.ignoreCheckState ? '是' : '否' }}
+        </template>
+      </el-table-column>
       <el-table-column
         :formatter="dateFormatter"
         align="center"


### PR DESCRIPTION
### 主要改动
- 列表页面：增加字段（忽略校验uri、忽略校验state）
- 表单页面：增加字段（回调地址、忽略校验uri、忽略校验state）
- 与后端对接，适配后端对 `system_social_client` 表新增的字段，保持前后端字段一致

### 变更原因
后端从非官方 `justauth-spring-boot-starter` 替换为官方的 `JustAuth` 的包，扩展`system_social_client`表的配置字段，前端改动用于配合该升级，后端读取三方应用的配置构建授权请求。

<img width="1650" alt="image" src="https://github.com/user-attachments/assets/e2420450-f9e6-4f5a-9000-ff7908d60904" />
