### PR TITLE
fix: remove @intlify/unplugin-vue-i18n to resolve init_runtime_dom_esm_bundler ReferenceError

### DIFF
--- a/build/vite/index.ts
+++ b/build/vite/index.ts
@@ -11,7 +11,6 @@ import Components from 'unplugin-vue-components/vite'
 import { ElementPlusResolver } from 'unplugin-vue-components/resolvers'
 import viteCompression from 'vite-plugin-compression'
 import topLevelAwait from 'vite-plugin-top-level-await'
-import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
 import { createSvgIconsPlugin } from 'vite-plugin-svg-icons-ng'
 import UnoCSS from 'unocss/vite'
 
@@ -68,11 +67,7 @@ export function createVitePlugins() {
       cache: false,
       include: ['src/**/*.vue', 'src/**/*.ts', 'src/**/*.tsx'] // 检查的文件
     }),
-    VueI18nPlugin({
-      runtimeOnly: true,
-      compositionOnly: true,
-      include: [resolve(__dirname, 'src/locales/**')]
-    }),
+
     createSvgIconsPlugin({
       iconDirs: [pathResolve('src/assets/svgs')],
       symbolId: 'icon-[dir]-[name]'


### PR DESCRIPTION
## Description

Fixes `ReferenceError: init_runtime_dom_esm_bundler is not defined` in both dev server and production builds when using Vue I18n with Vite 8.

## Root Cause

`@intlify/unplugin-vue-i18n` forces `vue-i18n` to use the `esm-bundler.js` entry via a resolve alias (`vue-i18n` → `vue-i18n/dist/vue-i18n.runtime.esm-bundler.js`). This esm-bundler entry contains references to esbuild/rolldown internal module initialization functions (`init_runtime_dom_esm_bundler`, `init_reactivity_esm_bundler`, `init_runtime_core_esm_bundler`, `init_shared_esm_bundler`). When the bundler splits code into chunks, these cross-chunk function references become orphaned, causing `ReferenceError` at runtime.

## Fix

Remove `@intlify/unplugin-vue-i18n` from the build. Without the plugin, `vue-i18n` uses its standard `.mjs` entry, which does NOT contain these problematic internal function references. Locale messages are then compiled at runtime rather than build-time, but functionality is unchanged.

## Testing

- ✅ Built without plugin — `init_runtime_dom_esm_bundler` does not appear in any output chunk
- ✅ Dev server: login page renders without errors
- ✅ Production build: no console errors

## References

- https://github.com/rolldown/rolldown/issues/9515 (Rolldown upstream bug)
- https://github.com/vbenjs/vue-vben-admin/issues/7955 (same error in vue-vben-admin)
