### PR TITLE
fix: cleanup component timers and listeners

### DIFF
--- a/src/components/Verifition/src/Verify/VerifySlide.vue
+++ b/src/components/Verifition/src/Verify/VerifySlide.vue
@@ -166,6 +166,25 @@ let secretKey = ref(''), //后端返回的ase加密秘钥
 const barArea = computed(() => {
   return proxy.$el.querySelector('.verify-bar-area')
 })
+const handleMove = (e) => {
+  move(e)
+}
+const handleEnd = () => {
+  end()
+}
+const removeDragListeners = () => {
+  window.removeEventListener('touchmove', handleMove)
+  window.removeEventListener('mousemove', handleMove)
+  window.removeEventListener('touchend', handleEnd)
+  window.removeEventListener('mouseup', handleEnd)
+}
+const addDragListeners = () => {
+  removeDragListeners()
+  window.addEventListener('touchmove', handleMove)
+  window.addEventListener('mousemove', handleMove)
+  window.addEventListener('touchend', handleEnd)
+  window.addEventListener('mouseup', handleEnd)
+}
 const init = () => {
   if (explain.value === '') {
     text.value = t('captcha.slide')
@@ -182,35 +201,8 @@ const init = () => {
     proxy.$parent.$emit('ready', proxy)
   })
 
-  window.removeEventListener('touchmove', function (e) {
-    move(e)
-  })
-  window.removeEventListener('mousemove', function (e) {
-    move(e)
-  })
+  addDragListeners()
 
-  //鼠标松开
-  window.removeEventListener('touchend', function () {
-    end()
-  })
-  window.removeEventListener('mouseup', function () {
-    end()
-  })
-
-  window.addEventListener('touchmove', function (e) {
-    move(e)
-  })
-  window.addEventListener('mousemove', function (e) {
-    move(e)
-  })
-
-  //鼠标松开
-  window.addEventListener('touchend', function () {
-    end()
-  })
-  window.addEventListener('mouseup', function () {
-    end()
-  })
 }
 watch(type, () => {
   init()
@@ -221,6 +213,9 @@ onMounted(() => {
   proxy.$el.onselectstart = function () {
     return false
   }
+})
+onBeforeUnmount(() => {
+  removeDragListeners()
 })
 //鼠标按下
 const start = (e) => {

--- a/src/layout/components/Message/src/Message.vue
+++ b/src/layout/components/Message/src/Message.vue
@@ -15,6 +15,7 @@ const userStore = useUserStoreWithOut()
 const activeName = ref('notice')
 const unreadCount = ref(0) // 未读消息数量
 const list = ref<any[]>([]) // 消息列表
+let unreadCountTimer: ReturnType<typeof setInterval> | undefined
 
 // 获得消息列表
 const getList = async () => {
@@ -42,7 +43,7 @@ onMounted(() => {
   // 首次加载小红点
   getUnreadCount()
   // 轮询刷新小红点
-  setInterval(
+  unreadCountTimer = setInterval(
     () => {
       if (userStore.getIsSetUser) {
         getUnreadCount()
@@ -52,6 +53,13 @@ onMounted(() => {
     },
     1000 * 60 * 2
   )
+})
+
+onBeforeUnmount(() => {
+  if (unreadCountTimer) {
+    clearInterval(unreadCountTimer)
+    unreadCountTimer = undefined
+  }
 })
 </script>
 <template>

--- a/src/views/mall/promotion/kefu/components/KeFuConversationList.vue
+++ b/src/views/mall/promotion/kefu/components/KeFuConversationList.vue
@@ -195,6 +195,7 @@ onMounted(() => {
 /** 组件卸载前 */
 onBeforeUnmount(() => {
   clearInterval(timer.value)
+  document.body.removeEventListener('click', closeRightMenu)
 })
 </script>
 


### PR DESCRIPTION
## 概述

本次 PR 修复组件卸载时未清理定时器和全局事件监听的问题。

## 修改内容

- 在 `Message.vue` 中清理站内信未读数量轮询定时器
- 在 `VerifySlide.vue` 中复用稳定的拖拽事件处理函数，确保全局事件监听可以被正确移除
- 在 `KeFuConversationList.vue` 组件卸载时移除 `document.body` 上的点击监听

## 修改原因

当组件被反复挂载和卸载时，未清理的定时器或全局事件监听可能导致重复触发、额外请求或内存泄漏。

## 测试情况

- 已执行 `pnpm lint:eslint`
- 执行 `pnpm ts:check` 失败，原因是项目中存在与本次改动无关的既有类型错误