### PR TITLE
fix(type): resolve ts:check errors on master baseline

### DIFF
--- a/src/views/bpm/model/CategoryDraggableModel.vue
+++ b/src/views/bpm/model/CategoryDraggableModel.vue
@@ -561,7 +561,7 @@ const initSort = useDebounceFn(() => {
   const table = document.querySelector(`.${props.categoryInfo.name} .el-table__body-wrapper tbody`)
   if (!table) return
 
-  Sortable.create(table, {
+  Sortable.create(table as HTMLElement, {
     group: 'shared',
     animation: 150,
     draggable: '.el-table__row',
@@ -569,9 +569,9 @@ const initSort = useDebounceFn(() => {
     onEnd: ({ newDraggableIndex, oldDraggableIndex }) => {
       if (oldDraggableIndex !== newDraggableIndex) {
         modelList.value.splice(
-          newDraggableIndex,
+          newDraggableIndex ?? 0,
           0,
-          modelList.value.splice(oldDraggableIndex, 1)[0]
+          modelList.value.splice(oldDraggableIndex ?? 0, 1)[0]
         )
       }
     }

--- a/src/views/crm/statistics/funnel/index.vue
+++ b/src/views/crm/statistics/funnel/index.vue
@@ -49,7 +49,7 @@
             v-for="item in statusTypeList"
             :key="item.id"
             :label="item.name"
-            :value="item.id"
+            :value="item.id!"
           />
         </el-select>
       </el-form-item>


### PR DESCRIPTION
修复 master 基线上的 4 处 TypeScript 类型检查错误，使 ts:check 通过。

## 变更

### src/views/bpm/model/CategoryDraggableModel.vue
- Sortable.create(table, ...) 中 table 为 document.querySelector 返回的 Element，显式断言为 HTMLElement
- onEnd 回调的 newDraggableIndex / oldDraggableIndex 可能为 undefined，用 ?? 0 兜底

### src/views/crm/statistics/funnel/index.vue
- el-option 的 :value 绑定 item.id (number | undefined)，用 item.id! 断言（与 codebase 中 contact/index.vue 等既有写法一致）

## 验证
- npm run ts:check：0 错误（修复前 4 个错误）
- eslint：通过
- npm run build:local：构建成功